### PR TITLE
return resp body when json.parse fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(url, cb) {
     try {
       parsed = JSON.parse(body);
     } catch (err) {
-      return cb(err);
+      return cb(err, body);
     }
     return cb(null, parsed);
   }));

--- a/test/index.js
+++ b/test/index.js
@@ -4,27 +4,41 @@ var through = require("event-stream").through;
 
 var GetJson = require("../index");
 
+var port = 3002
+  , url  = 'http://localhost:'+ port;
+
+function createServer(resp, cb) {
+  var server = http.createServer(function (req, res) {
+    if(req.method !== "GET"){
+      res.statusCode = 404;
+    } else {
+      res.write(resp);
+    }
+    res.end();
+  });
+  server.listen(port, function() { cb(server); });
+}
+
 describe("get-json tests", function(){
   it("should get json from server", function(done){
-
-    var server = http.createServer(function (req, res) {
-      if(req.method == "GET"){
-        var payload = {test: "fun times"};
-        res.write(JSON.stringify(payload));
-        res.end();
-
-      }else{
-        res.statusCode = 404;
-        res.end();
-      }
-    });
-
-    server.listen(3002, function(){
-      GetJson("http://localhost:3002", function(err, res) {
-        var expected = JSON.stringify({test:"fun times"});
-        assert(JSON.stringify(res) == expected, "response from server should match expected json");
+    var resp = JSON.stringify({ test: 'fun times' })
+    createServer(resp, function(server) {
+      GetJson(url, function(err, res) {
+        assert(JSON.stringify(res) === resp, "response from server should match expected json");
         server.close()
         done(err);
+      });
+    });
+  });
+
+  it("should return original body on err", function(done) {
+    var resp = 'whoops';
+    createServer(resp, function(server) {
+      GetJson(url, function(err, res) {
+        assert(err instanceof Error, "error on invalid json");
+        assert(res === resp, "method should return original body");
+        server.close()
+        done();
       });
     });
   });


### PR DESCRIPTION
Debugging bad requests w/ get-json is hard b/c you don't have access to the original response when the internal `JSON.parse` fails. One way to solve this is by returning the original response body as the second argument to the callback while setting the error the the thrown parse error. That way you can:

``` javascript
getJson(url, function(err, resp) {
  if (err) throw new Error('Failed to parse:'+ resp);
  ...
```

What do you think?
